### PR TITLE
feat: support new prop `focusedDate` ING-495

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A modern, beautiful, customizable date picker for React.
 
 ## Installation 🚀
 ```bash
-npm i @hassanmojab/react-modern-calendar-datepicker
+npm i @ornikar/react-modern-calendar-datepicker
 
 # or if you prefer Yarn:
-yarn add @hassanmojab/react-modern-calendar-datepicker
+yarn add @ornikar/react-modern-calendar-datepicker
 ```
 
 ## Documentation 📄

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # react-modern-calendar-datepicker
-[![Build Status](https://travis-ci.org/Kiarash-Z/react-modern-calendar-datepicker.svg?branch=master)](https://travis-ci.org/Kiarash-Z/react-modern-calendar-datepicker) [![codecov.io](https://codecov.io/github/kiarash-z/react-modern-calendar-datepicker/coverage.svg?branch=master)](https://codecov.io/github/kiarash-z/react-modern-calendar-datepicker?branch=master) ![npm](https://img.shields.io/npm/v/react-modern-calendar-datepicker)
+![npm](https://img.shields.io/npm/v/@ornikar/react-modern-calendar-datepicker)
 
 A modern, beautiful, customizable date picker for React.
+
+This is a fork of the great [react-modern-calendar-datepicker](https://github.com/Kiarash-Z/react-modern-calendar-datepicker).
 
 <a href="https://kiarash-z.github.io/react-modern-calendar-datepicker">
 	<img src="https://user-images.githubusercontent.com/20098648/76241893-f6722880-624a-11ea-9a80-eace8a4a27f0.png" alt="hero image" />
@@ -14,6 +16,9 @@ npm i @ornikar/react-modern-calendar-datepicker
 # or if you prefer Yarn:
 yarn add @ornikar/react-modern-calendar-datepicker
 ```
+
+## Fork
+- Add a new prop `focusedDate` to set a date we want to focus on at the initialization. Here are the [specs](website/src/constants/docsConstants.js#L110) and an [example](website/src/pages/docs/focused-date.js).
 
 ## Documentation 📄
 You can find documentation on [the website.](https://kiarash-z.github.io/react-modern-calendar-datepicker/)

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ export type Day = {
   day: number;
 };
 
+export type Month = Omit<Day, 'day'>;
+
 export type DayValue = Day | null | undefined;
 
 export type DayRange = { from: DayValue; to: DayValue };
@@ -23,6 +25,7 @@ export interface CalendarProps<TValue extends Value> {
   locale?: string | Locale;
   minimumDate?: Day;
   maximumDate?: Day;
+  focusedDate?: Day | Month;
   disabledDays?: Day[];
   shouldHighlightWeekends?: boolean;
   colorPrimary?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-modern-calendar-datepicker",
+  "name": "@ornikar/react-modern-calendar-datepicker",
   "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hassanmojab/react-modern-calendar-datepicker",
+  "name": "@ornikar/react-modern-calendar-datepicker",
   "version": "3.1.7",
-  "description": "A modern, beautiful, customizable date picker for React",
+  "description": "A modern, beautiful, customizable date picker for React - fork of Kiarash-Z",
   "main": "lib/index.js",
   "types": "index.d.ts",
   "scripts": {
@@ -20,14 +20,15 @@
     "lib",
     "index.d.ts"
   ],
-  "author": "Kiarash Zarinmehr",
-  "homepage": "https://kiarash-z.github.io/react-modern-calendar-datepicker",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/HassanMojab/react-modern-calendar-datepicker.git"
+    "url": "https://github.com/ornikar/react-modern-calendar-datepicker.git"
   },
   "bugs": {
-    "url": "https://github.com/HassanMojab/react-modern-calendar-datepicker/issues"
+    "url": "https://github.com/ornikar/react-modern-calendar-datepicker/issues"
   },
   "license": "MIT",
   "keywords": [

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -28,6 +28,7 @@ const Calendar = ({
   shouldHighlightWeekends,
   renderFooter,
   customDaysClassName,
+  focusedDate,
 }) => {
   const calendarElement = useRef(null);
   const [mainState, setMainState] = useState({
@@ -68,6 +69,14 @@ const Calendar = ({
   const toggleYearSelector = createStateToggler('isYearSelectorOpen');
 
   const getComputedActiveDate = () => {
+    if (focusedDate) {
+      return {
+        year: focusedDate.year,
+        month: focusedDate.month,
+        day: focusedDate.day || 1,
+      };
+    }
+
     const valueType = getValueType(value);
     if (valueType === TYPE_MUTLI_DATE && value.length) return shallowClone(value[0]);
     if (valueType === TYPE_SINGLE_DATE && value) return shallowClone(value);

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -34,6 +34,7 @@ const DatePicker = ({
   shouldHighlightWeekends,
   renderFooter,
   customDaysClassName,
+  focusedDate,
 }) => {
   const calendarContainerElement = useRef(null);
   const inputElement = useRef(null);
@@ -185,6 +186,7 @@ const DatePicker = ({
               shouldHighlightWeekends={shouldHighlightWeekends}
               renderFooter={renderFooter}
               customDaysClassName={customDaysClassName}
+              focusedDate={focusedDate}
             />
           </div>
           <div className="DatePicker__calendarArrow" />

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,14 +13,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-      "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
-      "requires": {
-        "browserslist": "^4.8.5",
-        "invariant": "^2.2.4",
-        "semver": "^5.5.0"
-      }
+      "version": "7.18.13",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+      "integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw=="
     },
     "@babel/core": {
       "version": "7.8.7",

--- a/website/src/constants/docsConstants.js
+++ b/website/src/constants/docsConstants.js
@@ -18,6 +18,10 @@ export const TUTORIAL_ITEMS = generateConstantId([
     name: 'Minimum & Maximum Date',
   },
   {
+    path: '/docs/focused-date',
+    name: 'Focused Date',
+  },
+  {
     path: '/docs/disabled-days',
     name: 'Disabled Day(s)',
   },
@@ -103,6 +107,7 @@ export const PROPS_TABLE_CALENDAR_ROWS = [
   ['locale', 'String', 'en', `Locale language of the calendar. It can be one of 'fa' or 'en'`],
   ['minimumDate', 'Object', `null`, 'Specifies the minimum selectable day by user'],
   ['maximumDate', 'Object', `null`, 'Specifies the maximum selectable day by user'],
+  ['focusedDate', 'Object', `null`, `Specifies the date you want to focus on at the initialization. You don't need to specify the day`],
   ['disabledDays', 'Array', `[]`, `An array of disabled calendar days. Disabled days won't be selectable, and
     they can't be included in a day range. If user tries to select/include them onDisabledDayError will be called`
   ],

--- a/website/src/pages/docs/focused-date.js
+++ b/website/src/pages/docs/focused-date.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Calendar } from 'react-modern-calendar-datepicker';
+
+import Docs from '../../containers/docs';
+import { Code } from '../../components';
+
+const FocusedDate = () => {
+  const [selectedDay, setSelectedDay] = useState(null);
+
+  return (
+    <Docs title="Focused Date">
+      <p>
+        There are many cases where you want to initialize your calendar with a
+        specific focused date. That&#39;s when{' '}
+        <code className="custom-code">focusedDate</code> prop comes in handy.
+        Here is an example:
+      </p>
+
+      <h2 className="Docs__titleSecondary">Focus a Past Date</h2>
+
+      <div className="Docs__sampleContainer">
+        <Code language="javascript">
+          {`
+import React, { useState } from "react";
+import "react-modern-calendar-datepicker/lib/DatePicker.css";
+import { Calendar } from "react-modern-calendar-datepicker";
+
+const App = () => {
+  const [selectedDay, setSelectedDay] = useState(null);
+  return (
+    <Calendar
+      value={selectedDay}
+      onChange={setSelectedDay}
+      focusedDate={{ year: 2013, month: 4 }}
+    />
+  );
+};
+
+export default App;
+
+          `}
+        </Code>
+        <Calendar
+          calendarClassName="fontWrapper"
+          value={selectedDay}
+          onChange={setSelectedDay}
+          focusedDate={{ year: 2013, month: 4 }}
+        />
+      </div>
+    </Docs>
+  );
+};
+
+export default FocusedDate;


### PR DESCRIPTION
### Context

In some cases, we need to initialize the calendar with a specific date. Especially when the minimum selectable date is in the future.

### Solution

Let's support a new prop `focusedDate` allowing us to set a date we want to focus on at the initialization.